### PR TITLE
[FEAT]: Add unified response format decoder

### DIFF
--- a/src/__tests__/internals.test.ts
+++ b/src/__tests__/internals.test.ts
@@ -1,0 +1,107 @@
+import Stencil from '../classes/stencil';
+import Internals from '../classes/internals';
+
+interface TestType {
+  id: number;
+  no: string;
+  imageUrl: string;
+  unitCode: {
+    id: number;
+    full: string;
+    iso: string;
+  };
+  image: {
+    data: null;
+  };
+  payment: {
+    address: {
+      id: number;
+      code: string;
+    };
+  };
+  categories: [
+    {
+      id: number;
+      code: string;
+    },
+  ];
+}
+
+function getLocalTestData() {
+  return {
+    data: [
+      {
+        id: 1,
+        attributes: {
+          no: 'TEST',
+          imageUrl: 'htto://localhost:1337/api/products/1/image',
+          unitCode: {
+            id: 1,
+            full: 'Stück',
+            iso: 'STK',
+          },
+          image: {
+            data: null,
+          },
+          payment: {
+            address: {
+              data: {
+                id: 1,
+                attributes: {
+                  code: 'TEST',
+                },
+              },
+            },
+          },
+          categories: {
+            data: [
+              {
+                id: 1,
+                attributes: {
+                  code: 'TEST',
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe('Transformation of unified data structure works as expected.', () => {
+  it('Flatten util works with array entities.', () => {
+    const data = getLocalTestData();
+    const products = Stencil.api.flatten<Array<TestType>>(data);
+
+    expect(products).toHaveLength(1);
+    expect(products?.[0]).toHaveProperty('id');
+    expect(products?.[0]).toHaveProperty('no');
+    expect(products?.[0]).toHaveProperty('imageUrl');
+    expect(products?.[0]).toHaveProperty('categories');
+    expect(products?.[0]).toHaveProperty('unitCode');
+    expect(products?.[0].categories?.[0]).toHaveProperty('id');
+    expect(products?.[0].categories?.[0]).toHaveProperty('code');
+
+    expect((products?.[0] as any).image).toBe(null);
+    expect(products?.[0].unitCode).toHaveProperty('iso');
+  });
+
+  it('Flatten util works with single entities.', () => {
+    const data = getLocalTestData();
+    const product = Stencil.api.flatten<TestType>({ data: data.data[0] });
+    expect(product).toHaveProperty('id');
+    expect(product).toHaveProperty('no');
+    expect(product).toHaveProperty('imageUrl');
+    expect(product).toHaveProperty('categories');
+    expect(product?.categories?.[0]).toHaveProperty('id');
+    expect(product?.categories?.[0]).toHaveProperty('code');
+  });
+
+  it('Internals have expected helpers', () => {
+    expect(Internals.struct).toBeDefined();
+    expect(Internals.isNull).toBeDefined();
+    expect(Internals.isProperty).toBeDefined();
+    expect(Internals.isComponent).toBeDefined();
+  });
+});

--- a/src/classes/internals.ts
+++ b/src/classes/internals.ts
@@ -1,0 +1,119 @@
+import Stencil from './stencil';
+import { UnifiedFormat } from '../types/query';
+
+class StencilInternals {
+  private static instance: StencilInternals;
+
+  private constructor() {}
+
+  /**
+   * The static method that controls the access to the stencil internals
+   * instance.
+   *
+   * This implementation let you subclass the StencilInternals class while
+   * keeping just one instance of each subclass around.
+   */
+  public static getInstance(): StencilInternals {
+    if (!StencilInternals.instance) {
+      StencilInternals.instance = new StencilInternals();
+    }
+
+    return StencilInternals.instance;
+  }
+
+  /**
+   * Determines if the property is null.
+   *
+   * @param obj The object to check
+   * @param key The key to check
+   * @returns {Boolean} If the property is null
+   */
+  isNull(obj: Record<string, any>, key: string): boolean {
+    return obj[key]?.data === null;
+  }
+
+  /**
+   * Determines if the property is a simple field like a number or a string
+   *
+   * @param obj The object to check
+   * @param key The key to check
+   * @returns {Boolean} If the property is a property
+   */
+  isProperty(obj: Record<string, any>, key: string) {
+    return (
+      (obj[key] === null || obj[key]?.data === undefined) &&
+      !(obj[key] instanceof Object) && // is not instance of object
+      !Array.isArray(obj[key]) // is not array
+    );
+  }
+
+  /**
+   * Determines if the property is a component or not. Components need to
+   * be distinguished from relations because they do not contain a `data`
+   * property.
+   *
+   * @param obj The object to check
+   * @param key The key to check
+   * @returns {Boolean} If the property is a property
+   */
+  isComponent(obj: Record<string, any>, key: string): boolean {
+    return (
+      (obj[key] instanceof Object &&
+        !obj[key].data &&
+        obj[key].data !== null) ||
+      Array.isArray(obj[key])
+    );
+  }
+
+  /**
+   * Takes in an object and returns a new object with the same properties but
+   * without the attributes key by using the spread operator.
+   *
+   * @param obj The object to sanitize
+   * @param isComponent If the response is a component
+   * @returns The sanitized object
+   */
+  struct(obj: Record<string, any>, isComponent?: boolean): any {
+    if (isComponent) return { ...obj };
+    return { id: obj.id, ...obj.attributes };
+  }
+
+  /**
+   * This is the function that recursively reformats the response from the API
+   * by calling `sanitize` and thus itself on each property of the response if
+   * required.
+   *
+   * #### Notice
+   *
+   * Usually this function is called by the `sanitize` function, than calling this
+   * function directly, it will call it with the `isComponent` flag set to `true` to
+   * indicate that the response is a component.
+   *
+   * @param {Object} obj - Property of the response from the API
+   * @param {Boolean} component - If the response is a component
+   * @returns {Object} The reformatted response
+   */
+  reformatResponse<T>(obj: UnifiedFormat, component?: boolean): T {
+    const structure = this.struct(obj, component);
+    for (const key of Object.keys(structure)) {
+      if (this.isProperty(structure, key)) {
+        continue;
+      }
+
+      if (this.isComponent(structure, key)) {
+        structure[key] = Stencil.api.flatten({ data: structure[key] }, true);
+        continue;
+      }
+
+      if (this.isNull(structure, key)) {
+        structure[key] = null;
+        continue;
+      }
+
+      structure[key] = Stencil.api.flatten(structure[key]);
+    }
+    return structure;
+  }
+}
+
+export default StencilInternals.getInstance();

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -170,3 +170,8 @@ export interface QueryOptions<T> {
    */
   locale?: Array<string> | string;
 }
+
+export interface UnifiedFormat {
+  id?: string;
+  attributes?: Record<string, any>;
+}


### PR DESCRIPTION
# Description

A new function that can be used to flatten any response from the API. The response is usually a deeply nested object (unified response format). This function will loop through each property of the object and remove all nesting.

Keep in mind when using this function, that the response is not always in the unified response format, like in the users-permissions plugin, if no data key is found in the response the function will throw accordingly.

#### Features

- Supports nested objects
- Supports arrays
- Supports null values
- Supports components
- Supports dynamic zones

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested? 

- [x] Added new test file for util `internals.test.ts`.
- [x] All existing tests pass with no errors

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
