### PR TITLE
[FEAT]: Add i18n helper for content type localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ popular headless CMS <a href="https://github.com/strapi/strapi">Strapi</a>.</p>
 
 Since version V4 of [Strapi](https://github.com/strapi/strapi) we have more control over filtering and controlling relations when using the REST API, this also introduces some complexity to requesting an API. Stencil aims to reduce this complexity.
 
-## Benefits
-
-Stencil offers two methods to build and parse queries using package [qs](https://github.com/ljharb/qs) under the hood as seen in the docs of [Strapi](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/filtering-locale-publication.html#filtering). This is Stencil's only direct dependency thus staying lightweight.
-
 ## Installation
 
 ```bash
@@ -40,21 +36,56 @@ interface Test {
     id: number;
     // array types are also supported
     images: Array<{ url: string }>;
-    relation: {
-        property: string;
-    }
+    relation: {  property: string; }
 }
 
-// offers perfect autocomplete with single generic
 const query = Stencil.stringify<Test>({
     filters: {
-        id: { $ne: 21 },
-        images: {
-            url: { $contains: "placehold.it" },
-        },
-        relation: {
-            property: { $in: ["example"] }
-        }
+      id: { 
+       $ne: 21 
+      },
+      images: {
+        url: { $contains: "placehold.it" }, 
+      },
+      relation: { 
+        property: { $in: ["example"] }
+      }
     }
 });
+```
+
+## Helpers
+
+The current version of Stencil.qs not only includes the type safe query string builder but some brand new features like:
+
+### Response Helper
+
+A new function that can be used to flatten any response from the API. The response is usually a deeply nested object (unified response format). This function will loop through each property of the object and remove all nesting.
+
+- [x] Supports nested objects
+- [x] Supports arrays
+- [x] Supports null values
+- [x] Supports components
+- [x] Supports dynamic zones
+
+Keep in mind When using this function, that the response is not always in the unified response format, like in the users-permissions plugin, if no data key is found in the response the function will throw accordingly.
+
+### Localization Helper
+
+With the new `i18n.single` and `i18n.array` you are able to not only flatten but automatically localize your content types received from the API.
+
+Both of the new helpers are completely type safe and you can pass the available locales as well as the content type that the response represents after being flattenend.
+
+```typescript
+import Stencil from 'stencil-qs';
+
+type Locales = "de" | "en";
+type Article = { id: string, title: string, description: string };
+
+// create query and include localizations
+const query = Stencil.stringify<Article[]>({ populate["localizations"] });
+const response = await (await fetch(`/articles?${query}`)).json();
+
+// would return Record<Locale, Article>[];
+const articles = Stencil.i18n.array<Locales, Article>(response); 
 ```

--- a/src/__tests__/internals.test.ts
+++ b/src/__tests__/internals.test.ts
@@ -27,12 +27,31 @@ interface TestType {
   ];
 }
 
+type Languages = 'de' | 'fr' | 'it';
+
 function getLocalTestData() {
   return {
     data: [
       {
         id: 1,
         attributes: {
+          localizations: {
+            data: [
+              {
+                id: 13,
+                attributes: {
+                  locale: 'fr',
+                },
+              },
+              {
+                id: 14,
+                attributes: {
+                  locale: 'it',
+                },
+              },
+            ],
+          },
+          locale: 'de',
           no: 'TEST',
           imageUrl: 'htto://localhost:1337/api/products/1/image',
           unitCode: {
@@ -104,5 +123,19 @@ describe('Transformation of unified data structure works as expected.', () => {
     expect(Internals.flatten).toBeDefined();
     expect(Internals.isProperty).toBeDefined();
     expect(Internals.isComponent).toBeDefined();
+  });
+
+  it('Localization util works as expected', () => {
+    const testData = getLocalTestData();
+    const testData2 = { data: testData.data[0] };
+
+    const entryArr = Stencil.i18n.array<Languages, TestType>(testData);
+    const entryObj = Stencil.i18n.single<Languages, TestType>(testData2);
+
+    const isInstanceArr = entryArr instanceof Array;
+    const isInstanceObj = entryObj instanceof Object;
+
+    expect(isInstanceArr).toBe(true);
+    expect(isInstanceObj).toBe(true);
   });
 });

--- a/src/classes/internals.ts
+++ b/src/classes/internals.ts
@@ -1,4 +1,11 @@
-import { UnifiedFormat } from '../types/query';
+import { injectorFactory } from '../utils/injections';
+
+import type {
+  Injection,
+  UnifiedFormat,
+  WithEntityID,
+  LocalizedResponse,
+} from '../types/query';
 
 class StencilInternals {
   private static instance: StencilInternals;
@@ -115,6 +122,59 @@ class StencilInternals {
   }
 
   /**
+   * This is the function that recursively localizes the response from the API
+   * by calling `localize` and thus itself on each property of the response if
+   * required.
+   *
+   * #### Notice
+   *
+   * Usually this function is called by the `localize` function, rather than calling this
+   * function directly, use the `localize` function.
+   *
+   * @param {Object} obj - Property of the response from the API
+   * @param {Boolean} component - If the response is a component
+   * @returns {Object} The reformatted response
+   */
+  localizeResponse<K extends string, T = any>(
+    sanitized: LocalizedResponse<T>,
+    inject?: Injection<K, T>,
+  ): Record<K, T> {
+    // If the response does not contain a localizations key, error
+    if (!sanitized?.localizations?.length) {
+      throw Error('No localizations found for this content type');
+    }
+
+    // If the response does not contain a locale key, error
+    if (!(sanitized as any)?.locale) {
+      throw Error('No locale found for this content type');
+    }
+
+    const localMap: Record<K, T> = {
+      [(sanitized as any).locale]: sanitized as T,
+    } as any;
+
+    for (const localization of sanitized.localizations) {
+      const { locale, ...rest } = localization as any;
+      (localMap as any)[locale as K] = { ...rest, locale } as any;
+    }
+
+    const injector: Injection<K, WithEntityID<T>> = injectorFactory<K, T>(
+      inject,
+    );
+
+    for (const key of Object.keys(localMap)) {
+      localMap[key as K] = injector(
+        localMap[key as K] as WithEntityID<T>,
+        sanitized as WithEntityID<LocalizedResponse<T>>,
+        key as K,
+      );
+    }
+
+    delete (localMap as any)[(sanitized as any).locale].localizations;
+    return localMap;
+  }
+
+  /**
    * This function is used to flatten any response from the API. The response
    * is usually a deeply nested object (unified response format). This function
    * will iterate over the object and remove all nesting.
@@ -157,6 +217,65 @@ class StencilInternals {
       return StencilInternals.getInstance().reformatResponse(item, isComponent);
     });
   }
+
+  i18n = {
+    /**
+     * The `i18n.t` function is used to localize a single or single response object from
+     * the API. It will iterate over the response and localize all strings, returning a
+     * new object with the locale as key and the flattened response as value.
+     *
+     * ### Keep in mind
+     *
+     * When using this function, that the response is not always in the
+     * unified response format, like in the users-permissions plugin, if no data key
+     * is found in the response the function will throw.
+     *
+     * Also keep in mind that this function will only localize the response if the
+     * locale key is present in the main entity and for each localization.
+     *
+     * @param {Object} response - The API response to localize
+     * @returns The localized entry
+     */
+    single<
+      K extends string = string,
+      T extends Record<any, any> = Record<any, any>,
+    >(response: any, inject?: Injection<K, T>): Record<K, T> {
+      const instance = StencilInternals.getInstance();
+      const sanitized: LocalizedResponse<T> = instance.flatten(response);
+      return instance.localizeResponse<K, T>(sanitized, inject);
+    },
+
+    /**
+     * The `i18n.array` function is used to localize a array response object from the API. It
+     * will iterate over the response and localize the content type, returning a new object
+     * with the locale as key and the flattened response as value.
+     *
+     * ### Keep in mind
+     *
+     * When using this function, that the response is not always in the
+     * unified response format, like in the users-permissions plugin, if no data key
+     * is found in the response the function will throw.
+     *
+     * Also keep in mind that this function will only localize the response if the
+     * locale key is present in the main entity and for each localization.
+     *
+     * @param {Object} response - The API response to localize
+     * @returns The localized entry
+     */
+    array<
+      K extends string = string,
+      T extends Record<any, any> = Record<any, any>,
+    >(response: any, inject?: Injection<K, T>): Array<Record<K, T>> {
+      const instance = StencilInternals.getInstance();
+      const sanitized: LocalizedResponse<T> = instance.flatten(response);
+      return sanitized.map((item: any) => {
+        return instance.localizeResponse<K, T>(
+          item as LocalizedResponse<T>,
+          inject,
+        );
+      });
+    },
+  };
 }
 
 export default StencilInternals.getInstance();

--- a/src/classes/stencil.ts
+++ b/src/classes/stencil.ts
@@ -44,6 +44,12 @@ class Stencil {
 
   /**
    * Stencil now also exports some handy functions to help you with the
+   * consumption of localized entries.
+   */
+  i18n = Stencil.internals.i18n;
+
+  /**
+   * Stencil now also exports some handy functions to help you with the
    * consumption of responses from the API.
    */
   api = {

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -179,3 +179,11 @@ export interface UnifiedFormat {
   id?: string;
   attributes?: Record<string, any>;
 }
+
+export type WithEntityID<T> = T & { id: string };
+
+export type LocalizedResponse<T> = T & { localizations: Array<T> };
+
+export type Injection<K, T> = (current: T, main: T, locale: K) => T;
+
+export type ExecutionType = 'single' | 'array';

--- a/src/utils/injections.ts
+++ b/src/utils/injections.ts
@@ -1,0 +1,12 @@
+import type { Injection, WithEntityID } from '../types/query';
+
+export function injectorFactory<K, T>(
+  inject?: Injection<K, T>,
+): Injection<K, WithEntityID<T>> {
+  if (!inject) {
+    const defaultInjector: Injection<K, WithEntityID<T>> = current => current;
+    return defaultInjector;
+  } else {
+    return inject as any as Injection<K, WithEntityID<T>>;
+  }
+}


### PR DESCRIPTION
# Description

With the new `i18n.single` and `i18n.array` you are able to not only flatten but automatically localize your content types received from the API.

## Example

You can now pass the response received by the API directly into the i18n helper and receive a localized map, containing each localization for every locale.

```typescript
import Stencil from 'stencil-qs';

type Locales = "de" | "en";
type Article = { id: string, title: string, description: string };

// create query and include localizations
const query = Stencil.stringify<Article[]>({ populate["localizations"] });
const response = await (await fetch(`/articles?${query}`)).json();

// would return Record<Locale, Article>[];
const articles = Stencil.i18n.array<Locales, Article>(response); 
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Existing tests run with no error or warnings.

- [x] Added new test for each of the utils functions.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
